### PR TITLE
Turn on FNO NOTAMS

### DIFF
--- a/stations/L30/KLAS.station
+++ b/stations/L30/KLAS.station
@@ -2078,7 +2078,7 @@
     {
       "text": "METERING, FLOW CONTROL, AND GATE HOLD PROCEDURES IN EFFECT.",
       "ordinal": 3,
-      "enabled": false
+      "enabled": true
     },
     {
       "text": "CHECK DENSITY ALTITUDE",

--- a/stations/SCT/KBUR.station
+++ b/stations/SCT/KBUR.station
@@ -2061,7 +2061,7 @@
     {
       "text": "METERING, FLOW CONTROL, AND GATE HOLD PROCEDURES IN EFFECT.",
       "ordinal": 5,
-      "enabled": false
+      "enabled": true
     },
     {
       "text": "STAFFING OPTIMIZED FOR EVENT TFC. NON-EVENT TFC EXPECT DELAYS. ADVISE IF YOU HAVE OUTDATED SCENERY.",

--- a/stations/SCT/KLAX.station
+++ b/stations/SCT/KLAX.station
@@ -2228,7 +2228,7 @@
     {
       "text": "METERING, FLOW CONTROL, AND GATE HOLD PROCEDURES IN EFFECT.",
       "ordinal": 4,
-      "enabled": false
+      "enabled": true
     }
   ]
 }

--- a/stations/SCT/KONT.station
+++ b/stations/SCT/KONT.station
@@ -2075,7 +2075,7 @@
     {
       "text": "METERING, FLOW CONTROL, AND GATE HOLD PROCEDURES IN EFFECT.",
       "ordinal": 3,
-      "enabled": false
+      "enabled": true
     },
     {
       "text": "USE CAUTION FOR NUMEROUS BIRDS OBSERVED IN VICINITY OF +ONT.",

--- a/stations/SCT/KPSP.station
+++ b/stations/SCT/KPSP.station
@@ -2079,7 +2079,7 @@
     {
       "text": "METERING, FLOW CONTROL, AND GATE HOLD PROCEDURES IN EFFECT.",
       "ordinal": 3,
-      "enabled": false
+      "enabled": true
     },
     {
       "text": "NEW RNAV PROCEDURES IN EFFECT. LOAD NEWEST NAVIGATION DATA.",

--- a/stations/SCT/KRNM.station
+++ b/stations/SCT/KRNM.station
@@ -1936,7 +1936,7 @@
       "id": "1251286e-96b0-4996-afb7-60d273104cb1",
       "ordinal": 1,
       "name": "East",
-      "airportConditions": "LNDG AND DEPG RWY 27.",
+      "airportConditions": "LNDG AND DEPG RWY 9.",
       "template": "[FACILITY] ATIS INFO [ATIS_CODE] [TIME]. [WX]. [ARPT_COND] [NOTAMS] [CLOSING]",
       "externalGenerator": {
         "enabled": false,

--- a/stations/SCT/KSAN.station
+++ b/stations/SCT/KSAN.station
@@ -2050,7 +2050,7 @@
     {
       "text": "METERING, FLOW CONTROL, AND GATE HOLD PROCEDURES IN EFFECT.",
       "ordinal": 1,
-      "enabled": false
+      "enabled": true
     },
     {
       "text": "NO OFFSHORE VFR TRANSITIONS.",

--- a/stations/SCT/KSNA.station
+++ b/stations/SCT/KSNA.station
@@ -2126,7 +2126,7 @@
     {
       "text": "METERING, FLOW CONTROL, AND GATE HOLD PROCEDURES IN EFFECT.",
       "ordinal": 2,
-      "enabled": false
+      "enabled": true
     },
     {
       "text": "STAFFING OPTIMIZED FOR EVENT TFC. NON-EVENT TFC EXPECT DELAYS. ADVISE IF YOU HAVE OUTDATED SCENERY.",


### PR DESCRIPTION
Turned on the FNO Metering NOTAM for the ZAB FNO. Fixed a typo in the new RNM profile.